### PR TITLE
Removed default value for the introduction column of the employees table

### DIFF
--- a/db/migrate/20231121113245_change_introduction_column_default.rb
+++ b/db/migrate/20231121113245_change_introduction_column_default.rb
@@ -1,0 +1,5 @@
+class ChangeIntroductionColumnDefault < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :employees, :introduction, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_16_112937) do
+ActiveRecord::Schema.define(version: 2023_11_21_113245) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 2023_11_16_112937) do
     t.string "first_name", null: false
     t.string "last_name_furigana", null: false
     t.string "first_name_furigana", null: false
-    t.text "introduction", default: ""
+    t.text "introduction"
     t.date "birthdate", null: false
     t.string "prefecture", null: false
     t.boolean "is_active", default: true, null: false


### PR DESCRIPTION
Mysqlではemployeesテーブルのintroductionカラムのデフォルト値""が受け入れられなかったため削除