### PR TITLE
Add default value for the introduction column of the employees table

### DIFF
--- a/app/views/public/employees/edit.html.erb
+++ b/app/views/public/employees/edit.html.erb
@@ -7,7 +7,7 @@
     <div class="form">
       <p class="form__item"><%= f.label "氏名" %></p>
       <p class="form__item"><%= f.text_field :last_name, autofocus: true, placeholder: "姓", class: "form-text" %></p>
-      <p class="form__item"><%= f.text_field :last_name, autofocus: true, placeholder: "姓", class: "form-text" %></p>
+      <p class="form__item"><%= f.text_field :first_name, autofocus: true, placeholder: "姓", class: "form-text" %></p>
     </div>
     <div class="form">
       <p class="form__item"><%= f.label "氏名(カナ)" %></p>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -4,7 +4,7 @@
     <div class="form">
       <p class="form__item"><%= f.label "氏名" %></p>
       <p class="form__item"><%= f.text_field :last_name, autofocus: true, placeholder: "姓", class: "form-text" %></p>
-      <p class="form__item"><%= f.text_field :last_name, autofocus: true, placeholder: "姓", class: "form-text" %></p>
+      <p class="form__item"><%= f.text_field :first_name, autofocus: true, placeholder: "姓", class: "form-text" %></p>
     </div>
     <div class="form">
       <p class="form__item"><%= f.label "氏名(カナ)" %></p>

--- a/db/migrate/20231121114525_change_column_default_to_employees.rb
+++ b/db/migrate/20231121114525_change_column_default_to_employees.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultToEmployees < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :employees, :introduction, from: nil, to: "自己紹介文を設定しましょう！"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_21_113245) do
+ActiveRecord::Schema.define(version: 2023_11_21_114525) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 2023_11_21_113245) do
     t.string "first_name", null: false
     t.string "last_name_furigana", null: false
     t.string "first_name_furigana", null: false
-    t.text "introduction"
+    t.text "introduction", default: "自己紹介文を設定しましょう！"
     t.date "birthdate", null: false
     t.string "prefecture", null: false
     t.boolean "is_active", default: true, null: false


### PR DESCRIPTION
一度はデフォルト値を削除したが、社員詳細ページで表示することになる「自己紹介文を設定しましょう！」をデフォルト値に設定しても良いと考え直し、再度修正。
登録内容変更ボタンから、という記述はボタン名を固定してしまうため除外。
なお、社員詳細ページでは自己紹介文が設定されていない場合メッセージを表示するように設定しているが、そちらはデフォルト値を削除された時のことを考え、残したままとする。