### PR TITLE
Change the size method on the employee details page to the present me…

### DIFF
--- a/app/views/public/employees/show.html.erb
+++ b/app/views/public/employees/show.html.erb
@@ -28,10 +28,10 @@
   <div class="introduction-field__item">
     <h2>自己紹介</h2>
     <div class="text-box">
-      <% if @employee.introduction.size == 0 %>
-        <h4>登録内容変更ボタンから自己紹介文を設定しましょう！</h4>
-      <% else %>
+      <% if @employee.introduction.present? %>
         <%= @employee.introduction %>
+      <% else %>
+        <h4>登録内容変更ボタンから自己紹介文を設定しましょう！</h4>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
employeesテーブルのintroductionカラムのdefault値を削除したため、社員詳細ページで自己紹介文表示の条件分岐の条件として使われていたsizeメソッドをpresentメソッドに変更